### PR TITLE
Feature/assignment 6

### DIFF
--- a/server/Program.cs
+++ b/server/Program.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using server.SERVER_CORE;
+using System;
 using System.IO;
 using System.Linq;
 
@@ -45,10 +46,13 @@ namespace server
             }
 
             Console.WriteLine("PORT: " + port);
-            Console.WriteLine("PATH: " + path);          
+            Console.WriteLine("PATH: " + path);
+
+            HTTPServer server = new HTTPServer((int)port);
+            server.Start();
 
             //Infinite loop... until 'exit' command is typed
-            while(server_is_running)
+            while (server_is_running)
             {
                 _input = Console.ReadLine();
                 _input = _input.ToLower();

--- a/server/SERVER_CORE/HTTPClient.cs
+++ b/server/SERVER_CORE/HTTPClient.cs
@@ -34,7 +34,10 @@ namespace server.SERVER_CORE
             
         }
 
-        public void BeginRequest() { }
+        public void BeginRequest()
+        {
+            Console.WriteLine("Begin Request Called!");
+        }
 
         public void Dispose()
         {

--- a/server/SERVER_CORE/HTTPServer.cs
+++ b/server/SERVER_CORE/HTTPServer.cs
@@ -24,6 +24,7 @@ namespace server.SERVER_CORE
         private Dictionary<HTTPClient, bool> _clients = new Dictionary<HTTPClient, bool>();
         private AutoResetEvent _clientsChangedEvent = new AutoResetEvent(false);
 
+
         public HTTPServer(int port)
         {
             this._state = HTTPServerState.STATE.STOPPED;
@@ -36,7 +37,6 @@ namespace server.SERVER_CORE
             ReadTimeout = new TimeSpan(0, 1, 30);
             WriteTimeout = new TimeSpan(0, 1, 30);
             ShutdownTimeout = new TimeSpan(0, 0, 30);
-
         }
 
         private void BeginAcceptTcpClient()
@@ -70,7 +70,7 @@ namespace server.SERVER_CORE
                 client.BeginRequest();
                 BeginAcceptTcpClient();
             }
-            catch(ObjectDisposedException ex)
+            catch (ObjectDisposedException ex)
             {
                 Console.WriteLine(ex.Message);
             }
@@ -119,7 +119,7 @@ namespace server.SERVER_CORE
 
         public event EventHandler StateChanged;
 
-        //You should handle the event delegate within the function. Remember to check if the event is null first.
+        // You should handle the event delegate within the function. Remember to check if the event is null first.
         protected virtual void OnChangedState(EventArgs args)
         {
             EventHandler handler = StateChanged;

--- a/server/SERVER_CORE/HTTPServer.cs
+++ b/server/SERVER_CORE/HTTPServer.cs
@@ -2,13 +2,14 @@
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
+using System.Threading;
 
 namespace server.SERVER_CORE
 {
     public class HTTPServer : IDisposable
     {
        
-        private HTTPServerState.STATE _state;
+        private HTTPServerState.STATE _state = HTTPServerState.STATE.STOPPED;
         private int _readBufferSize;
         private int _writeBufferSize;
         private string _serverBanner;
@@ -21,10 +22,11 @@ namespace server.SERVER_CORE
         private bool _disposed = false;
         private object _syncLock = new object();
         private Dictionary<HTTPClient, bool> _clients = new Dictionary<HTTPClient, bool>();
-
+        private AutoResetEvent _clientsChangedEvent = new AutoResetEvent(false);
 
         public HTTPServer(int port)
         {
+            this._state = HTTPServerState.STATE.STOPPED;
             this.Port = port;
             this._endPoint = new IPEndPoint(IPAddress.Loopback, this.Port);
 
@@ -38,13 +40,55 @@ namespace server.SERVER_CORE
         }
 
         private void BeginAcceptTcpClient()
-        { }
+        {
+            var listener = _listener;
+            if (listener == null)
+            {
+                throw new NullReferenceException("Listener is null");
+            }
+            listener.BeginAcceptTcpClient(AcceptTcpClientCallback, listener);
+        }
 
         private void AcceptTcpClientCallback(IAsyncResult iar)
-        { }
+        {
+            try
+            {
+                var listener = _listener;
+                if (listener == null)
+                {
+                    return;
+                }
+
+                var tcpClient = listener.EndAcceptTcpClient(iar);
+                if (State == HTTPServerState.STATE.STOPPED)
+                {
+                    tcpClient.Close();
+                }
+
+                var client = new HTTPClient(this, tcpClient);
+                RegisterClient(client);
+                client.BeginRequest();
+                BeginAcceptTcpClient();
+            }
+            catch(ObjectDisposedException ex)
+            {
+                Console.WriteLine(ex.Message);
+            }
+
+        }
 
         private void RegisterClient(HTTPClient client)
-        { }
+        {
+            if (client == null)
+            {
+                throw new ArgumentNullException("Client received from param is null");
+            }
+            lock (_syncLock)
+            {
+                _clients.Add(client, false);
+                _clientsChangedEvent.Set();
+            }
+        }
 
         private void VerifyState(HTTPServerState.STATE state)
         {
@@ -56,11 +100,13 @@ namespace server.SERVER_CORE
 
         public void Start()
         {
+            VerifyState(HTTPServerState.STATE.STOPPED);
             this._state = HTTPServerState.STATE.STARTING;
             this._listener = new TcpListener(EndPoint);
             this._listener.Start();
             this.EndPoint = this._listener.LocalEndpoint as IPEndPoint;
             this._state = HTTPServerState.STATE.STARTED;
+            BeginAcceptTcpClient();
         }
 
         public void Stop()
@@ -70,7 +116,20 @@ namespace server.SERVER_CORE
             this._listener = null;
             this._state = HTTPServerState.STATE.STOPPED;
         }
-        
+
+        public event EventHandler StateChanged;
+
+        //You should handle the event delegate within the function. Remember to check if the event is null first.
+        protected virtual void OnChangedState(EventArgs args)
+        {
+            EventHandler handler = StateChanged;
+
+            if (handler != null)
+            {
+                handler(this, args);
+            }
+        }
+
         public int Port
         {
             get { return this._port; }
@@ -119,9 +178,29 @@ namespace server.SERVER_CORE
             set { this._shutdownTimeout = value; }
         }
 
+        public HTTPServerState.STATE State
+        {
+            get { return this._state; }
+            private set
+            {
+                this._state = value;
+                OnChangedState(EventArgs.Empty);
+            }
+        }
+
         public void Dispose()
         {
-            _disposed = true;
+            if (!_disposed)
+            {
+                if (_state == HTTPServerState.STATE.STARTED)
+                    Stop();
+                if (_clientsChangedEvent != null)
+                {
+                    ((IDisposable)_clientsChangedEvent).Dispose();
+                    _clientsChangedEvent = null;
+                }
+                _disposed = true;
+            }
         }
 
     }


### PR DESCRIPTION
Create a new EventHandler delegate called StateChanged. Here's some documentation.
Create a new function to handle the StateChanged event called OnStateChanged. The access should be protected and it should be overridable.
You should handle the event delegate within the function. Remember to check if the event is null first.
Update the State property implementation so it fires up the event once the server state is updated.
Add a VerifyState(HttpServerState.Stopped); call as the first line on your Start function.
Implement your BeginAcceptTcpClient function. It should perform the following:
It should copy the _listener member to a local variable.
You should check your local variable, it shouldn't be null.
You should call the BeginAcceptTcpClient from your listener local object. The callback function should be the previously defined AcceptTcpClientCallback private function.
Implement your AcceptTcpClientCallback function. It should perform the following:
It should copy the _listener member to a local variable.
You should check your local variable, it shouldn't be null. If null, you should just return.
Call the EndAcceptTcpClient function from your local listener object and capture it's return value into a local variable named tcpClient.
You should check if the server has been stopped, if so call the Close function of your tcpClient object.
Instantiate a new HttpClient object.
Call the RegisterClient function and pass your new client object.
The RegisterClient function should perform the following steps:
Check if the client parameter is null, if so throw a new argument exception.
Perform a lock using the previously defined _synclock object.
Add the client to the clients dictionary.
Call the Set function of your clientsChangedEvent member.
Call the BeginRequest function of your new object.
Call the BeginAcceptTcpClient function again.
